### PR TITLE
Include HOME in build environment

### DIFF
--- a/pythonforandroid/archs.py
+++ b/pythonforandroid/archs.py
@@ -140,6 +140,10 @@ class Arch:
     def get_env(self, with_flags_in_cc=True):
         env = {}
 
+        # HOME: User's home directory
+        if 'HOME' in environ:
+            env['HOME'] = environ['HOME']
+
         # CFLAGS/CXXFLAGS: the processor flags
         env['CFLAGS'] = ' '.join(self.common_cflags).format(target=self.target)
         if self.arch_cflags:


### PR DESCRIPTION
Many of the tools run by p4a store intermediate files in the user's home
directory. Passing the HOME environment variable to the build
environment has 2 positive effects:

1. To completely encapsulate the build, HOME can be set to an alternate
   directory than the user's actual home directory. Many tools such as
   p4a have options to override these paths, but that must be done on a
   case by case basis and it would require that p4a pass through these
   options or environment variables.

2. In containerized environments the user may not be registered in the
   accounts database. If the user's home directory can't be found from
   the HOME environment variable or the accounts database, many tools
   will fail. An example of this is python2.7 when run by `ndk-build`.

I sent this upstream in kivy/python-for-android#2582, but I have no idea when it will be merged. The ultimate goal I have here is to allow building as an unprivileged user in docker without defining a user in the container. Then you don't need to copy things in and out of the container. That only works if p4a doesn't filter out the `HOME` environment variable.