### PR TITLE
Support multiarch in webview bootstrap

### DIFF
--- a/pythonforandroid/bootstraps/webview/__init__.py
+++ b/pythonforandroid/bootstraps/webview/__init__.py
@@ -21,31 +21,28 @@ class WebViewBootstrap(Bootstrap):
             with open('local.properties', 'w') as fileh:
                 fileh.write('sdk.dir={}'.format(self.ctx.sdk_dir))
 
-        arch = self.ctx.archs[0]
-        if len(self.ctx.archs) > 1:
-            raise ValueError('built for more than one arch, but bootstrap cannot handle that yet')
-        info('Bootstrap running with arch {}'.format(arch))
-
         with current_directory(self.dist_dir):
             info('Copying python distribution')
 
-            self.distribute_libs(arch, [self.ctx.get_libs_dir(arch.arch)])
-            self.distribute_aars(arch)
             self.distribute_javaclasses(self.ctx.javaclass_dir,
                                         dest_dir=join("src", "main", "java"))
 
-            python_bundle_dir = join(f'_python_bundle__{arch.arch}', '_python_bundle')
-            ensure_dir(python_bundle_dir)
-            site_packages_dir = self.ctx.python_recipe.create_python_bundle(
-                join(self.dist_dir, python_bundle_dir), arch)
+            for arch in self.ctx.archs:
+                self.distribute_libs(arch, [self.ctx.get_libs_dir(arch.arch)])
+                self.distribute_aars(arch)
+
+                python_bundle_dir = join(f'_python_bundle__{arch.arch}', '_python_bundle')
+                ensure_dir(python_bundle_dir)
+                site_packages_dir = self.ctx.python_recipe.create_python_bundle(
+                    join(self.dist_dir, python_bundle_dir), arch)
+                if not self.ctx.with_debug_symbols:
+                    self.strip_libraries(arch)
+                self.fry_eggs(site_packages_dir)
 
             if 'sqlite3' not in self.ctx.recipe_build_order:
                 with open('blacklist.txt', 'a') as fileh:
                     fileh.write('\nsqlite3/*\nlib-dynload/_sqlite3.so\n')
 
-        if not self.ctx.with_debug_symbols:
-            self.strip_libraries(arch)
-        self.fry_eggs(site_packages_dir)
         super().assemble_distribution()
 
 


### PR DESCRIPTION
This is essentially exactly the same as the sdl2 bootstrap.

It looks like this is all that's needed. Why it wasn't in 41c6cc07dbbf0405a71098d46c38d2e33334c5da, I don't know.