### PR TITLE
Prefer avdmanager from cmdline-tools

### DIFF
--- a/pythonforandroid/build.py
+++ b/pythonforandroid/build.py
@@ -113,7 +113,11 @@ def select_and_check_toolchain_version(sdk_dir, ndk_dir, arch, ndk_sysroot_exist
 
 
 def get_targets(sdk_dir):
-    if exists(join(sdk_dir, 'tools', 'bin', 'avdmanager')):
+    if exists(join(sdk_dir, 'cmdline-tools', 'latest', 'bin', 'avdmanager')):
+        avdmanager = sh.Command(join(sdk_dir, 'cmdline-tools', 'latest', 'bin', 'avdmanager'))
+        targets = avdmanager('list', 'target').stdout.decode('utf-8').split('\n')
+
+    elif exists(join(sdk_dir, 'tools', 'bin', 'avdmanager')):
         avdmanager = sh.Command(join(sdk_dir, 'tools', 'bin', 'avdmanager'))
         targets = avdmanager('list', 'target').stdout.decode('utf-8').split('\n')
     elif exists(join(sdk_dir, 'tools', 'android')):


### PR DESCRIPTION
The Android SDK tools are deprecated in favor of the command line tools.
Trying to use avdmanager from the deprecated tools fails on OpenJDK 11
with since it can't find the `javax/xml/bind/annotation/XmlSchema`
class. Try `cmdline-tools/latest/bin/avdmanager` first.

(cherry picked from commit d71ef6a82a5d8c43c7a5e11bb24d3aef6254a20a)